### PR TITLE
feat: add syntax highlighting to chat editor

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -281,3 +281,138 @@
 .markdown-content h3:first-child {
   margin-top: 0;
 }
+
+/* Syntax Highlighting - Light Theme */
+.hljs {
+  color: #24292e;
+  background: transparent;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #6a737d;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-addition {
+  color: #d73a49;
+}
+
+.hljs-number,
+.hljs-string,
+.hljs-meta .hljs-meta-string,
+.hljs-literal,
+.hljs-doctag,
+.hljs-regexp {
+  color: #032f62;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #6f42c1;
+}
+
+.hljs-attribute,
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-class .hljs-title,
+.hljs-type {
+  color: #005cc5;
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-subst,
+.hljs-meta,
+.hljs-meta .hljs-keyword,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-link {
+  color: #22863a;
+}
+
+.hljs-built_in,
+.hljs-deletion {
+  color: #b31d28;
+}
+
+.hljs-formula {
+  background: #f6f8fa;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+/* Syntax Highlighting - Dark Theme */
+.dark .hljs {
+  color: #e1e4e8;
+}
+
+.dark .hljs-comment,
+.dark .hljs-quote {
+  color: #8b949e;
+  font-style: italic;
+}
+
+.dark .hljs-keyword,
+.dark .hljs-selector-tag,
+.dark .hljs-addition {
+  color: #ff7b72;
+}
+
+.dark .hljs-number,
+.dark .hljs-string,
+.dark .hljs-meta .hljs-meta-string,
+.dark .hljs-literal,
+.dark .hljs-doctag,
+.dark .hljs-regexp {
+  color: #a5d6ff;
+}
+
+.dark .hljs-title,
+.dark .hljs-section,
+.dark .hljs-name,
+.dark .hljs-selector-id,
+.dark .hljs-selector-class {
+  color: #d2a8ff;
+}
+
+.dark .hljs-attribute,
+.dark .hljs-attr,
+.dark .hljs-variable,
+.dark .hljs-template-variable,
+.dark .hljs-class .hljs-title,
+.dark .hljs-type {
+  color: #79c0ff;
+}
+
+.dark .hljs-symbol,
+.dark .hljs-bullet,
+.dark .hljs-subst,
+.dark .hljs-meta,
+.dark .hljs-meta .hljs-keyword,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-pseudo,
+.dark .hljs-link {
+  color: #7ee787;
+}
+
+.dark .hljs-built_in,
+.dark .hljs-deletion {
+  color: #ffa198;
+}
+
+.dark .hljs-formula {
+  background: #161b22;
+}

--- a/components/markdown-preview.tsx
+++ b/components/markdown-preview.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useMemo, useRef, useState } from "react"
+import { useMemo, useRef, useState, useEffect } from "react"
 import { marked } from "marked"
+import hljs from "highlight.js"
 import { Check, Copy } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
@@ -21,6 +22,14 @@ export function MarkdownPreview({ content, showCopyButton = true }: MarkdownPrev
     })
     return marked.parse(content || "") as string
   }, [content])
+
+  useEffect(() => {
+    if (previewRef.current) {
+      previewRef.current.querySelectorAll("pre code").forEach((block) => {
+        hljs.highlightElement(block as HTMLElement)
+      })
+    }
+  }, [html])
 
   const copyRenderedContent = async () => {
     if (previewRef.current) {

--- a/components/shared-document-view.tsx
+++ b/components/shared-document-view.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useRef } from "react"
 import { marked } from "marked"
+import hljs from "highlight.js"
 import { Check, Copy, FileText, Moon, Sun, Monitor, Link, Pencil } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -49,6 +50,14 @@ export function SharedDocumentView({ content, documentId }: SharedDocumentViewPr
     mediaQuery.addEventListener("change", handleChange)
     return () => mediaQuery.removeEventListener("change", handleChange)
   }, [theme])
+
+  useEffect(() => {
+    if (contentRef.current) {
+      contentRef.current.querySelectorAll("pre code").forEach((block) => {
+        hljs.highlightElement(block as HTMLElement)
+      })
+    }
+  }, [html])
 
   const copyContent = async () => {
     if (contentRef.current) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cmdk": "1.0.4",
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.5.1",
+    "highlight.js": "11.11.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
     "marked": "17.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       embla-carousel-react:
         specifier: 8.5.1
         version: 8.5.1(react@19.2.0)
+      highlight.js:
+        specifier: 11.11.1
+        version: 11.11.1
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1416,6 +1419,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
@@ -2964,6 +2971,8 @@ snapshots:
   get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
+
+  highlight.js@11.11.1: {}
 
   iceberg-js@0.8.1: {}
 


### PR DESCRIPTION
This PR introduces syntax highlighting for the chat Markdown editor, significantly improving the readability of code snippets.

**Problem/Issue/Goal:**
- Code snippets within the chat Markdown editor were not formatted, making them difficult to read and distinguish from regular text.

**Fix/Solution:**
- Implemented syntax highlighting functionality using `highlight.js`.
- Updated the preview components to correctly render highlighted code.
- Added custom CSS to style the syntax-highlighted code blocks.

Chat link: https://v0.app/chat/fiM0dC5ftyA